### PR TITLE
Adding autofocus support

### DIFF
--- a/src/checkbox-field/README.md
+++ b/src/checkbox-field/README.md
@@ -21,6 +21,12 @@ are standard HTML attributes, so refer to official documentation there:
  * `name`
  * `value`
 
+### autofocus
+
+Since `autofocus` is used by the browser to focus a field onload, it doesn't
+really work the same in the context of something like deku. Thus, this prop
+uses `afterMount` to manually focus the input after being added to the DOM.
+
 ### Validation
 
 These attributes are applied directly to the `<input>` and are used for validation. These

--- a/src/checkbox-field/index.js
+++ b/src/checkbox-field/index.js
@@ -9,6 +9,9 @@ import * as Field from '../field';
  * Available props
  */
 export let propTypes = {
+  // Supports automatically focusing the input on mount.
+  autofocus: { type: 'boolean' },
+
   // Sets the checkbox as checked.
   checked: { type: 'boolean' },
 
@@ -56,6 +59,16 @@ export let defaultProps = {
     return el.validationMessage;
   }
 };
+
+/**
+ * The afterMount hook is only used to autofocus the input. (when enabled)
+ *
+ * @param {Object} component
+ * @param {HTMLElement} el
+ */
+export function afterMount({ props }, el) {
+  if (props.autofocus) el.getElementsByTagName('input')[0].focus();
+}
 
 /**
  * Renders a field with a single <input>, generally used as some sort of text

--- a/src/input-field/README.md
+++ b/src/input-field/README.md
@@ -28,6 +28,12 @@ are standard HTML attributes, so refer to official documentation there:
  * `type`
  * `value`
 
+### autofocus
+
+Since `autofocus` is used by the browser to focus a field onload, it doesn't
+really work the same in the context of something like deku. Thus, this prop
+uses `afterMount` to manually focus the input after being added to the DOM.
+
 ### Validation
 
 These attributes are applied directly to the `<input>` and are used for validation. These

--- a/src/input-field/index.js
+++ b/src/input-field/index.js
@@ -9,6 +9,9 @@ import * as Field from '../field';
  * Available props
  */
 export let propTypes = {
+  // Supports automatically focusing the input on mount.
+  autofocus: { type: 'boolean' },
+
   // Adds custom CSS classes to the form field.
   class: { type: 'string' },
 
@@ -108,6 +111,16 @@ export let defaultProps = {
     return el.validationMessage;
   }
 };
+
+/**
+ * The afterMount hook is only used to autofocus the input. (when enabled)
+ *
+ * @param {Object} component
+ * @param {HTMLElement} el
+ */
+export function afterMount({ props }, el) {
+  if (props.autofocus) el.getElementsByTagName('input')[0].focus();
+}
 
 /**
  * Renders a field with a single <input>, generally used as some sort of text

--- a/src/select-field/README.md
+++ b/src/select-field/README.md
@@ -24,6 +24,12 @@ These attributes are passed directly to the [Select](../select) component:
  * `size`
  * `value`
 
+### autofocus
+
+Since `autofocus` is used by the browser to focus a field onload, it doesn't
+really work the same in the context of something like deku. Thus, this prop
+uses `afterMount` to manually focus the input after being added to the DOM.
+
 ### Validation
 
 These attributes are applied directly to the `<input>`/`<textare>` and are used for validation.

--- a/src/select-field/index.js
+++ b/src/select-field/index.js
@@ -10,6 +10,9 @@ import * as Select from '../select';
  * Available props
  */
 export let propTypes = {
+  // Supports automatically focusing the input on mount.
+  autofocus: { type: 'boolean' },
+
   // Adds custom CSS classes to the form field.
   class: { type: 'string' },
 
@@ -69,6 +72,16 @@ export let defaultProps = {
     return el.validationMessage;
   }
 };
+
+/**
+ * The afterMount hook is only used to autofocus the input. (when enabled)
+ *
+ * @param {Object} component
+ * @param {HTMLElement} el
+ */
+export function afterMount({ props }, el) {
+  if (props.autofocus) el.getElementsByTagName('select')[0].focus();
+}
 
 /**
  * An input control for accepting text input, using an `input[type=text]`

--- a/src/text-field/README.md
+++ b/src/text-field/README.md
@@ -25,6 +25,12 @@ These are standard HTML attributes, so refer to official documentation there:
  * `size`
  * `value`
 
+### autofocus
+
+Since `autofocus` is used by the browser to focus a field onload, it doesn't
+really work the same in the context of something like deku. Thus, this prop
+uses `afterMount` to manually focus the input after being added to the DOM.
+
 ### multiline
 
 When this attribute is set, the control will be a `<textarea>`. (by default, a plain `<input>`

--- a/src/text-field/index.js
+++ b/src/text-field/index.js
@@ -9,6 +9,9 @@ import * as Field from '../field';
  * Available props
  */
 export let propTypes = {
+  // Supports automatically focusing the input on mount.
+  autofocus: { type: 'boolean' },
+
   // Adds custom CSS classes to the form field.
   class: { type: 'string' },
 
@@ -91,6 +94,18 @@ export let defaultProps = {
     return el.validationMessage;
   }
 };
+
+/**
+ * The afterMount hook is only used to autofocus the input. (when enabled)
+ *
+ * @param {Object} component
+ * @param {HTMLElement} el
+ */
+export function afterMount({ props }, el) {
+  if (props.autofocus) {
+    el.getElementsByTagName(props.multiline ? 'textarea' : 'input')[0].focus();
+  }
+}
 
 /**
  * An input control for accepting text input, using an `input[type=text]`

--- a/test/checkbox-field.js
+++ b/test/checkbox-field.js
@@ -158,5 +158,11 @@ describe('CheckboxField', function () {
         });
       }); // run after current stack so error handler has fired
     });
+
+    it('should autofocus the select', function () {
+      let app = mount(<CheckboxField autofocus />);
+      let control = app.element.querySelector('input');
+      assert.strictEqual(control, document.activeElement, `expected ${control.outerHTML} to have focus`);
+    });
   });
 });

--- a/test/input-field.js
+++ b/test/input-field.js
@@ -241,5 +241,11 @@ describe('InputField', function () {
         }); // wait for change event to trigger state change
       }); // run after current stack so error handler has fired
     });
+
+    it('should autofocus the input', function () {
+      let app = mount(<InputField autofocus name="name" />);
+      let control = app.element.querySelector('input');
+      assert.strictEqual(control, document.activeElement, `expected ${control.outerHTML} to have focus`);
+    });
   });
 });

--- a/test/select-field.js
+++ b/test/select-field.js
@@ -179,5 +179,11 @@ describe('SelectField', function () {
         });
       }); // run after current stack so error handler has fired
     });
+
+    it('should autofocus the select', function () {
+      let app = mount(<SelectField autofocus />);
+      let control = app.element.querySelector('select');
+      assert.strictEqual(control, document.activeElement, `expected ${control.outerHTML} to have focus`);
+    });
   });
 });

--- a/test/text-field.js
+++ b/test/text-field.js
@@ -274,5 +274,17 @@ describe('TextField', function () {
         }); // wait for change event to trigger state change
       }); // run after current stack so error handler has fired
     });
+
+    it('should autofocus the input', function () {
+      let app = mount(<TextField autofocus />);
+      let control = app.element.querySelector('input');
+      assert.strictEqual(control, document.activeElement, `expected ${control.outerHTML} to have focus`);
+    });
+
+    it('should autofocus the textarea', function () {
+      let app = mount(<TextField autofocus multiline />);
+      let control = app.element.querySelector('textarea');
+      assert.strictEqual(control, document.activeElement, `expected ${control.outerHTML} to have focus`);
+    });
   });
 });


### PR DESCRIPTION
This fixes #12 by adding support for `autofocus` to each of the field types. Since the `autofocus` attribute doesn't work directly here, it's being supported via `afterMount` hooks.
